### PR TITLE
feat: integrate Redis Stream publisher (Upstash REST API) for Slack ingestion events

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,16 +2,17 @@
 
 KMS is an AI-powered knowledge oracle for SaaS/fintech teams. It integrates with tools like Slack, GitHub, and Jira to eliminate onboarding friction and knowledge silos. KMS extracts and organizes contextual knowledge to instantly answer developer questions such as:
 
-> "Who owns the billing service?"
+> "Who owns the billing service?"  
 > "What PR fixed the incident last week?"
 
 ## 🧠 MVP Scope
 
 This repository currently implements the **Slack ingestion** feature:
 
-- A `/ingest` endpoint to receive Slack event webhooks
-- Stores raw events in Supabase
-- Built with clean architecture principles (handlers → service → repository → storage port)
+- A `/ingest` endpoint to receive Slack event webhooks  
+- Stores raw events in Supabase  
+- Publishes ingestion events asynchronously to Redis Streams (Upstash REST API) for downstream processing  
+- Built with clean architecture principles (handlers → service → repository → storage/publisher ports)
 
 ## 📁 Project Structure
 
@@ -20,7 +21,7 @@ kms/
 ├── api/
 │   ├── domain/            # Core business models and interfaces
 │   ├── handlers/          # HTTP handlers (e.g. /ingest)
-│   ├── repository/        # Implementation of storage interfaces (Supabase)
+│   ├── repository/        # Implementation of storage interfaces (Supabase, Redis publisher)
 │   ├── services/          # Business logic layer (SlackService)
 │   └── main.go            # Application entrypoint
 ```
@@ -41,6 +42,8 @@ Create a `.env` file:
 ```env
 SUPABASE_URL=your-supabase-project-url
 SUPABASE_KEY=your-service-role-key
+REDIS_UPSTASH_URL=your-upstash-rest-url
+REDIS_UPSTASH_TOKEN=your-upstash-rest-token
 PORT=8080
 ```
 
@@ -62,15 +65,17 @@ curl -X POST http://localhost:8080/ingest \
 
 - **Go (Gin)** — Web framework
 - **Supabase** — Storage backend
+- **Redis Streams (Upstash REST API)** — Asynchronous job queue for ingestion events
 - **Clean Architecture** — Maintainable project structure
 
 ## 🔜 Upcoming Features
 
-- Slack event validation
-- Async job processing with Redis Streams
+- Slack event signature verification for security
+- Async consumer to process Redis stream events
+- Retry and backpressure handling for Redis publishing
 - GitHub/Jira ingestion modules
 - AI/NLP pipeline (spaCy, Pinecone)
-- Slackbot MVP with contextual Q&A
+- Slackbot MVP with contextual Q\&A
 
 ## 🤝 Contributing
 

--- a/api/domain/publisher.go
+++ b/api/domain/publisher.go
@@ -1,0 +1,16 @@
+package domain
+
+import "context"
+
+type JobPayload struct {
+	ID        string `json:"id"`
+	RecordID  string `json:"record_id" binding:"required"`
+	Source    string `json:"source" binding:"required,oneof=slack"`
+	Content   string `json:"content" binding:"required"`
+	EntityID  string `json:"entity_id,omitempty"`
+	CreatedAt string `json:"created_at" binding:"required"`
+}
+
+type Publisher interface {
+	Publish(ctx context.Context, stream string, payload JobPayload) error
+}

--- a/api/domain/slack.go
+++ b/api/domain/slack.go
@@ -31,7 +31,7 @@ type IngestRequest struct {
 }
 
 type SlackRepository interface {
-	IngestRepo(ctx context.Context, data IngestRequest) error
+	IngestRepo(ctx context.Context, data JobPayload) error
 }
 
 type SlackService interface {

--- a/api/handlers/slack.go
+++ b/api/handlers/slack.go
@@ -1,7 +1,6 @@
 package handlers
 
 import (
-	"log"
 	"net/http"
 
 	"github.com/gin-gonic/gin"
@@ -33,6 +32,5 @@ func (sh *SlackHandler) IngestHandler(c *gin.Context) {
 		return
 	}
 
-	log.Printf("Received Slack data: %+v", req)
 	c.JSON(http.StatusOK, gin.H{"message": "Message received successfully", "data": req})
 }

--- a/api/main.go
+++ b/api/main.go
@@ -20,12 +20,19 @@ func main() {
 		log.Println("No .env file found, proceeding with defaults")
 	}
 
-	url := os.Getenv("SUPABASE_URL")
-	key := os.Getenv("SUPABASE_KEY")
+	supabase_url := os.Getenv("SUPABASE_URL")
+	supabase_key := os.Getenv("SUPABASE_KEY")
 
-	storage := repository.NewSupabaseRepo(url, key)
+	upstash_url := os.Getenv("UPSTASH_REDIS_REST_URL")
+	upstash_token := os.Getenv("UPSTASH_REDIS_REST_TOKEN")
+
+	// Initialize storage and publisher
+	storage := repository.NewSupabaseRepo(supabase_url, supabase_key)
+	publisher := repository.NewRedisStreamPublisher(upstash_url, upstash_token)
+
+	// Initialize repositories and services
 	repo := repository.NewSlackRepo(storage)
-	service := services.NewSlackService(repo)
+	service := services.NewSlackService(repo, publisher)
 	handlers.SetupRoutes(r, service)
 
 	port := os.Getenv("PORT")

--- a/api/repository/redis_publisher.go
+++ b/api/repository/redis_publisher.go
@@ -1,0 +1,71 @@
+package repository
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"log"
+	"net/http"
+	"net/url"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/nahom-zewdu/kMS/api/domain"
+)
+
+type RedisStreamPublisher struct {
+	BaseURL string
+	Token   string
+	Client  *http.Client
+}
+
+func NewRedisStreamPublisher(baseURL, token string) domain.Publisher {
+	return &RedisStreamPublisher{
+		BaseURL: baseURL,
+		Token:   token,
+		Client:  &http.Client{},
+	}
+}
+
+func (rp *RedisStreamPublisher) Publish(ctx context.Context, stream string, job domain.JobPayload) error {
+	id := "*"
+	recordID := uuid.New().String()
+	now := time.Now().UTC().Format(time.RFC3339)
+
+	// Build path-based URL
+	path := fmt.Sprintf("%s/xadd/%s/%s/source/%s/content/%s/created_at/%s/record_id/%s",
+		rp.BaseURL,
+		stream,
+		id,
+		recordID,
+		url.PathEscape(job.Source),
+		url.PathEscape(job.Content),
+		url.PathEscape(now),
+	)
+
+	if job.EntityID != "" {
+		path += fmt.Sprintf("/entity_id/%s", url.PathEscape(job.EntityID))
+	}
+
+	req, err := http.NewRequestWithContext(ctx, "POST", path, nil)
+	if err != nil {
+		return err
+	}
+
+	req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", rp.Token))
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := rp.Client.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode >= 300 {
+		bodyBytes, _ := io.ReadAll(resp.Body)
+		return fmt.Errorf("failed to publish to Redis stream: %s, response: %s", resp.Status, string(bodyBytes))
+	}
+
+	log.Printf("Successfully published to Redis stream %s", stream)
+
+	return nil
+}

--- a/api/repository/redis_publisher.go
+++ b/api/repository/redis_publisher.go
@@ -9,7 +9,6 @@ import (
 	"net/url"
 	"time"
 
-	"github.com/google/uuid"
 	"github.com/nahom-zewdu/kMS/api/domain"
 )
 
@@ -29,15 +28,14 @@ func NewRedisStreamPublisher(baseURL, token string) domain.Publisher {
 
 func (rp *RedisStreamPublisher) Publish(ctx context.Context, stream string, job domain.JobPayload) error {
 	id := "*"
-	recordID := uuid.New().String()
 	now := time.Now().UTC().Format(time.RFC3339)
 
 	// Build path-based URL
-	path := fmt.Sprintf("%s/xadd/%s/%s/source/%s/content/%s/created_at/%s/record_id/%s",
+	path := fmt.Sprintf("%s/xadd/%s/%s/record_id/%s/source/%s/content/%s/created_at/%s/",
 		rp.BaseURL,
 		stream,
 		id,
-		recordID,
+		url.PathEscape(job.RecordID),
 		url.PathEscape(job.Source),
 		url.PathEscape(job.Content),
 		url.PathEscape(now),

--- a/api/repository/slack.go
+++ b/api/repository/slack.go
@@ -2,7 +2,6 @@ package repository
 
 import (
 	"context"
-	"time"
 
 	"github.com/google/uuid"
 	"github.com/nahom-zewdu/kMS/api/domain"
@@ -16,21 +15,20 @@ func NewSlackRepo(storage domain.StoragePort) domain.SlackRepository {
 	return &SlackRepo{storage: storage}
 }
 
-func (sr *SlackRepo) IngestRepo(ctx context.Context, data domain.IngestRequest) error {
-	id := uuid.New().String()
-	now := time.Now().UTC()
+func (sr *SlackRepo) IngestRepo(ctx context.Context, job domain.JobPayload) error {
 
 	insertPayload := map[string]interface{}{
-		"id":      id,
-		"source":  data.Source,
-		"content": data.Content,
+		"id":        uuid.New().String(),
+		"source":    job.Source,
+		"content":   job.Content,
+		"record_id": job.RecordID,
 		"entity_id": func() interface{} {
-			if data.EntityID == "" {
+			if job.EntityID == "" {
 				return nil
 			}
-			return data.EntityID
+			return job.EntityID
 		}(),
-		"created_at": now,
+		"created_at": job.CreatedAt,
 	}
 
 	return sr.storage.Insert(ctx, "raw_data", insertPayload)

--- a/api/services/slack.go
+++ b/api/services/slack.go
@@ -2,23 +2,43 @@ package services
 
 import (
 	"context"
+	"time"
 
+	"github.com/google/uuid"
 	"github.com/nahom-zewdu/kMS/api/domain"
 )
 
 type SlackService struct {
-	repo domain.SlackRepository
+	repo      domain.SlackRepository
+	publisher domain.Publisher
 }
 
-func NewSlackService(repo domain.SlackRepository) domain.SlackService {
+func NewSlackService(repo domain.SlackRepository, publisher domain.Publisher) domain.SlackService {
 	return &SlackService{
-		repo: repo,
+		repo:      repo,
+		publisher: publisher,
 	}
 }
 
 func (ss *SlackService) IngestService(ctx context.Context, data domain.IngestRequest) error {
+	var job domain.JobPayload
 
-	err := ss.repo.IngestRepo(ctx, data)
+	job.ID = "*"
+	job.RecordID = uuid.New().String()
+	job.Source = data.Source
+	job.Content = data.Content
+
+	if data.EntityID != "" {
+		job.EntityID = data.EntityID
+	}
+	job.CreatedAt = time.Now().UTC().Format(time.RFC3339)
+
+	err := ss.repo.IngestRepo(ctx, job)
+	if err != nil {
+		return err
+	}
+
+	err = ss.publisher.Publish(ctx, "slack_jobs", job)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
# Description

This PR introduces a Redis Stream publisher implemented via Upstash's REST API to enhance the Slack ingestion flow in the KMS project.

**Key changes include:**

* Added `JobPayload` data model and `Publisher` interface for job queue abstraction.
* Implemented `RedisStreamPublisher` with Upstash REST API for publishing ingestion events to Redis streams.
* Refined the Slack service to populate common fields, generate unique `record_id`, and coordinate ingestion and publishing.
* Fixed URL path construction order for Redis XADD command to comply with Upstash API requirements.
* Improved repository and service layers for cleaner separation and validation using `JobPayload`.
* Removed debug logs from the Slack ingestion handler for cleaner production logs.

---

# How to test

* Ensure `.env` contains valid `SUPABASE_URL`, `SUPABASE_KEY`, `REDIS_UPSTASH_URL`, and `REDIS_UPSTASH_TOKEN`.
* Run the API locally or in your dev environment.
* Send a Slack event payload to `/ingest` endpoint.
* Verify data is stored in Supabase and also published to Redis stream `slack_jobs` via Upstash.
* Use Upstash dashboard or `redis-cli` to confirm stream entries.

---

# Suggested Next Steps

* Add validation on `JobPayload` before publishing.
* Implement retries with exponential backoff for Redis publish failures.
* Add integration tests for Redis publisher and ingestion flow.
* Implement metrics and monitoring for publisher success/failure.
* Consider adding consumers to process stream data downstream.

---

# Diff Summary (key files)

```diff
api/domain/domain.go
+ Added JobPayload struct
+ Added Publisher interface for job queue abstraction
+ Updated SlackRepository and SlackService interfaces to use JobPayload

api/services/slack_service.go
+ Modified IngestService to construct JobPayload with UUID and timestamps
+ Injected Publisher dependency and call Publish after repository ingestion

api/repository/redis_publisher.go
+ Implemented RedisStreamPublisher using Upstash REST API for XADD command
+ Fixed URL path formatting to match Upstash API expected parameter order
+ Added HTTP client and authentication header support

api/repository/slack_repo.go
+ Updated IngestRepo method to accept JobPayload instead of IngestRequest

api/handlers/slack_handler.go
- Removed debug log on ingestion handler

main.go
+ Initialized RedisStreamPublisher from environment variables
+ Injected Redis publisher into SlackService

```
